### PR TITLE
Changed _next_read_ms to _last_read_ms to prevent millis() rollover

### DIFF
--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
   "name": "rdm6300",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "keywords": "rdm6300, rfid",
   "description": "A simple library to interface with rdm6300 rfid reader.",
   "repository":

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Rdm6300
-version=1.1.1
+version=1.1.2
 author=Arad Eizen
 maintainer=Arad Eizen <https://github.com/arduino12>
 sentence=A simple library to interface with rdm6300 rfid reader.

--- a/src/rdm6300.cpp
+++ b/src/rdm6300.cpp
@@ -89,12 +89,12 @@ bool Rdm6300::update(void)
 	/* if a new tag appears- return it */
 	if (_last_tag_id != tag_id) {
 		_last_tag_id = tag_id;
-		_next_read_ms = 0;
+		_last_read_ms = 0;
 	}
 	/* if the old tag is still here set tag_id to zero */
-	if (_next_read_ms > millis())
+	if (is_tag_near())
 		tag_id = 0;
-	_next_read_ms = millis() + RDM6300_NEXT_READ_MS;
+	_last_read_ms = millis();
 
 	_tag_id = tag_id;
 	return tag_id;
@@ -102,7 +102,7 @@ bool Rdm6300::update(void)
 
 bool Rdm6300::is_tag_near(void)
 {
-	return _next_read_ms > millis();
+	return millis() - _last_read_ms < RDM6300_NEXT_READ_MS;
 }
 
 uint32_t Rdm6300::get_tag_id(void)

--- a/src/rdm6300.h
+++ b/src/rdm6300.h
@@ -49,7 +49,7 @@ class Rdm6300
 		Stream *_stream = NULL;
 		uint32_t _tag_id = 0;
 		uint32_t _last_tag_id = 0;
-		uint32_t _next_read_ms = 0;
+		uint32_t _last_read_ms = 0;
 };
 
 #endif


### PR DESCRIPTION
Hi. Upon inspection of the source code, I saw you were checking if the tag was still near by setting `_next_read_ms` to a future value. This is not a good approach since `millis()` [overflows every 50 days](https://www.arduino.cc/reference/en/language/functions/time/millis/). The appropriate approach is to mark a previous millis and compare with the current value, as shown on this [StackOverflow answer](https://arduino.stackexchange.com/a/12588) and also used on the [BlinkWithoutDelay Arduino example](https://www.arduino.cc/en/Tutorial/BlinkWithoutDelay).

So what I did was change `_next_read_ms` to `_last_read_ms` and update `is_tag_near()` to see if `millis() - _last_read_ms < RDM6300_NEXT_READ_MS`.