### PR TITLE
Add listen function for external call.

### DIFF
--- a/examples/multiple_software_serials/multiple_software_serials.ino
+++ b/examples/multiple_software_serials/multiple_software_serials.ino
@@ -1,0 +1,77 @@
+/*
+ * A simple example to interface with multiple software serials.
+ * Use multiple software serials on some boards can only listen one UART at a time like Uno.
+ * 
+ * Note:
+ *     You can use it for connect other software serials devices not only rdm6300.
+ *     In these case, we use two rdm6300 readers for example.
+ * 
+ *     The LED pin of rdm6300 is set at 5V (HIGH) at initial, 
+ *     and if an RFID was read, the LED pin goes to 0V (LOW) for some moments.
+ *     We can use this property to switch between two devices,
+ *     but it still can only read from a device at a time.
+ * 
+ *     And be aware about usage of listening switch between devices.
+ * 
+ * Connections:
+ *     | Uno | rdm6300-1 | rdm6300-2 | notes                               |
+ *     |-----+-----------+-----------+-------------------------------------|
+ *     | D5  | TX        |           |                                     |
+ *     | D6  | LED       |           |                                     |
+ *     | D7  |           | TX        |                                     |
+ *     | D8  |           | LED       |                                     |
+ *     | GND | GND       | GND       |                                     |
+ *     | VCC | VCC       | VCC       | The rdm6300 must be powered with 5V |
+ * 
+ * Zeng (https://github.com/asas1asas200)
+ */
+
+#include <rdm6300.h>
+
+#define RDM6300_1_RX_PIN	5
+#define RDM6300_1_LED_PIN	6
+#define RDM6300_2_RX_PIN	7
+#define RDM6300_2_LED_PIN	8
+
+Rdm6300 rdm6300_1;
+Rdm6300 rdm6300_2;
+
+Rdm6300 *current_rdm6300;
+
+void setup()
+{
+	Serial.begin(115200);
+	pinMode(RDM6300_1_LED_PIN, INPUT);
+	pinMode(RDM6300_2_LED_PIN, INPUT);
+
+	rdm6300_1.begin(RDM6300_1_RX_PIN);
+	rdm6300_2.begin(RDM6300_2_RX_PIN);
+
+	rdm6300_1.listen();
+	current_rdm6300 = &rdm6300_1;
+
+	Serial.println("Place RFID tag near any rdm6300...");
+}
+
+void loop()
+{
+	// checkout listening if needed
+	if (digitalRead(RDM6300_1_LED_PIN) == LOW
+			&& !rdm6300_1.is_listening()) {
+		Serial.println("Switch to listening RDM6300_1");
+		rdm6300_1.listen();
+		current_rdm6300 = &rdm6300_1;
+	} else if (digitalRead(RDM6300_2_LED_PIN) == LOW
+			&& !rdm6300_2.is_listening()) {
+		Serial.println("Switch to listening RDM6300_2");
+		rdm6300_2.listen();
+		current_rdm6300 = &rdm6300_2;
+	}
+
+	/* If you use rdm6300 with other devices, you had better set a TIMEOUT and run a while-loop to
+		make sure the tag can be read correctely. */
+	if (current_rdm6300->update()) 
+		Serial.println(current_rdm6300->get_tag_id(), HEX);
+	
+	delay(10);
+}

--- a/keywords.txt
+++ b/keywords.txt
@@ -11,11 +11,13 @@ Rdm6300	KEYWORD1
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
-begin		KEYWORD2
-end			KEYWORD2
-update		KEYWORD2
-get_tag_id	KEYWORD2
-is_tag_near	KEYWORD2
+begin			KEYWORD2
+end				KEYWORD2
+update			KEYWORD2
+get_tag_id		KEYWORD2
+is_tag_near		KEYWORD2
+listen			KEYWORD2
+is_listening	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)

--- a/src/rdm6300.cpp
+++ b/src/rdm6300.cpp
@@ -123,7 +123,7 @@ void Rdm6300::listen(void)
 	_serial->listen();
 }
 
-bool Rdm6300::isListening(void)
+bool Rdm6300::is_listening(void)
 {
 	return _serial->isListening();
 }

--- a/src/rdm6300.cpp
+++ b/src/rdm6300.cpp
@@ -117,3 +117,8 @@ uint32_t Rdm6300::get_tag_id(void)
 	_tag_id = 0;
 	return tag_id;
 }
+
+void Rdm6300::listen(void)
+{
+	_serial->listen();
+}

--- a/src/rdm6300.cpp
+++ b/src/rdm6300.cpp
@@ -118,12 +118,14 @@ uint32_t Rdm6300::get_tag_id(void)
 	return tag_id;
 }
 
+#ifdef RDM6300_SOFTWARE_SERIAL
 void Rdm6300::listen(void)
 {
-	_serial->listen();
+	_software_serial->listen();
 }
 
 bool Rdm6300::is_listening(void)
 {
-	return _serial->isListening();
+	return _software_serial->isListening();
 }
+#endif

--- a/src/rdm6300.cpp
+++ b/src/rdm6300.cpp
@@ -122,3 +122,8 @@ void Rdm6300::listen(void)
 {
 	_serial->listen();
 }
+
+bool Rdm6300::isListening(void)
+{
+	return _serial->isListening();
+}

--- a/src/rdm6300.h
+++ b/src/rdm6300.h
@@ -40,6 +40,7 @@ class Rdm6300
 		bool update(void);
 		uint32_t get_tag_id(void);
 		bool is_tag_near(void);
+		void listen(void);
 	private:
 #ifdef RDM6300_HARDWARE_SERIAL
 		HardwareSerial *_hardware_serial = NULL;

--- a/src/rdm6300.h
+++ b/src/rdm6300.h
@@ -40,8 +40,10 @@ class Rdm6300
 		bool update(void);
 		uint32_t get_tag_id(void);
 		bool is_tag_near(void);
+#ifdef RDM6300_SOFTWARE_SERIAL
 		void listen(void);
 		bool is_listening(void);
+#endif
 	private:
 #ifdef RDM6300_HARDWARE_SERIAL
 		HardwareSerial *_hardware_serial = NULL;

--- a/src/rdm6300.h
+++ b/src/rdm6300.h
@@ -41,6 +41,7 @@ class Rdm6300
 		uint32_t get_tag_id(void);
 		bool is_tag_near(void);
 		void listen(void);
+		bool isListening(void);
 	private:
 #ifdef RDM6300_HARDWARE_SERIAL
 		HardwareSerial *_hardware_serial = NULL;

--- a/src/rdm6300.h
+++ b/src/rdm6300.h
@@ -41,7 +41,7 @@ class Rdm6300
 		uint32_t get_tag_id(void);
 		bool is_tag_near(void);
 		void listen(void);
-		bool isListening(void);
+		bool is_listening(void);
 	private:
 #ifdef RDM6300_HARDWARE_SERIAL
 		HardwareSerial *_hardware_serial = NULL;


### PR DESCRIPTION
I have added a listen function to call the internal listen function of `_serial`.

If I use Arduino UNO, I can only use one `SoftwareSerial` at a time.
And the `SoftwareSerial.listen()` function can help us to switch between multiple serials.
Add this feature for more flexibility.