### PR TITLE
Use HWSERIAL1 to detect HW serial mode

### DIFF
--- a/src/rdm6300.h
+++ b/src/rdm6300.h
@@ -9,12 +9,10 @@
 
 #include <Arduino.h>
 
-#if defined(ARDUINO_ARCH_ESP32) || defined(ARDUINO_ARCH_ESP8266) || defined(ARDUINO_ARCH_SAMD)
-	#define RDM6300_HARDWARE_SERIAL
-#endif
-
-#if !(defined(ARDUINO_ARCH_ESP32) || defined(ARDUINO_ARCH_SAMD))
-	#define RDM6300_SOFTWARE_SERIAL
+#if defined(HWSERIAL1)
+    #define RDM6300_HARDWARE_SERIAL
+#elif
+    #define RDM6300_SOFTWARE_SERIAL
 #endif
 
 #ifdef RDM6300_HARDWARE_SERIAL


### PR DESCRIPTION
Hi!
I have Nano Every and I want to use HW serial, but there is no directive for this. I thought to add `ARDUINO_AVR_NANO_EVERY`, but HW serial must be complied only for boards with Serial1 or more, as you mentioned in comment https://github.com/arduino12/rdm6300/blob/a8ddb5fb153177d049141c1307f9e542f49bbaa3/examples/hardware_uart/hardware_uart.ino#L5

So, I added `HWSERIAL1` to check this and avoid describing board list. What do you think?